### PR TITLE
unbiased scale for DRIVE

### DIFF
--- a/fedjax/aggregators/compression.py
+++ b/fedjax/aggregators/compression.py
@@ -275,7 +275,8 @@ def drive_pytree(params: Params) -> Params:
   leaves, tree_def = jax.tree_util.tree_flatten(params)
   new_leaves = []
   for leaf in leaves:
-    new_leaves.append(jnp.sum(jnp.abs(leaf)) * jnp.sign(leaf) / leaf.size)
+    # this uses the unbiased scale from section 4.2 in DRIVE's paper (Scale = norm2(R(x))**2 / norm1(R(x)) )
+    new_leaves.append(jnp.sum(jnp.power(leaf, 2)) * jnp.sign(leaf) / jnp.sum(jnp.abs(leaf)))
   return jax.tree_util.tree_unflatten(tree_def, new_leaves)
 
 

--- a/fedjax/aggregators/compression_test.py
+++ b/fedjax/aggregators/compression_test.py
@@ -137,7 +137,8 @@ class CompressionTest(absltest.TestCase):
   def test_structured_drive_pytree(self):
     x = {'w': jnp.array([1., -2., 3.])}
     y = compression.drive_pytree(x)
-    npt.assert_array_equal(y['w'], jnp.array([2., -2., 2.]))
+    npt.assert_array_almost_equal(
+        y['w'], jnp.array([2.333333, -2.333333,  2.333333]), decimal=4)
 
   def test_structured_drive_quantizer(self):
     delta_params_and_weights = [('a', {
@@ -159,7 +160,8 @@ class CompressionTest(absltest.TestCase):
     mean_aggregated_params = sum([
         aggregated_params['w'] for aggregated_params in aggregated_params_list
     ]) / 100
-    npt.assert_array_equal(mean_aggregated_params, [0.9375, 0.9375, 4.0625])
+    npt.assert_array_almost_equal(
+        mean_aggregated_params, [1.458334, 1.458334, 6.125], decimal=4)
 
   def test_terngrad_quantize_identity(self):
     # If the vector has only two distinct values and sigma > 2.5 * v_max,


### PR DESCRIPTION
Following a discussion with @stheertha, I suggest using the unbiased scale (section 4.2 in [Drive's paper](https://proceedings.neurips.cc/paper/2021/hash/0397758f8990c1b41b81b43ac389ab9f-Abstract.html)) for cases where there is more than 1 client.

Thank you for considering.